### PR TITLE
Feature/post-like-view

### DIFF
--- a/src/main/java/mooyeol/snsservice/config/SpringConfig.java
+++ b/src/main/java/mooyeol/snsservice/config/SpringConfig.java
@@ -1,5 +1,7 @@
 package mooyeol.snsservice.config;
 
+import mooyeol.snsservice.repository.heart.HeartRepository;
+import mooyeol.snsservice.repository.heart.HeartRepositoryImpl;
 import mooyeol.snsservice.repository.member.H2MemberRepository;
 import mooyeol.snsservice.repository.member.MemberRepository;
 import mooyeol.snsservice.repository.post.PostRepository;
@@ -18,5 +20,10 @@ public class SpringConfig {
     @Bean
     public PostRepository postRepository() {
         return new PostRepositoryImpl();
+    }
+
+    @Bean
+    public HeartRepository heartRepository() {
+        return new HeartRepositoryImpl();
     }
 }

--- a/src/main/java/mooyeol/snsservice/controller/PostController.java
+++ b/src/main/java/mooyeol/snsservice/controller/PostController.java
@@ -1,6 +1,5 @@
 package mooyeol.snsservice.controller;
 
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mooyeol.snsservice.domain.Member;
@@ -42,8 +41,6 @@ public class PostController {
         if (principal instanceof Member) {
             isLoggedIn = true;
         }
-
-        log.info("is Member ???? ={}", isLoggedIn);
 
         Optional<Post> optionalPost = postService.findPost(id, isLoggedIn);
         if (optionalPost.isEmpty())
@@ -121,5 +118,17 @@ public class PostController {
         }
 
         return result;
+    }
+
+
+    @PostMapping("/post/like/{id}")
+    public ResponseEntity<Object> likePost(@AuthenticationPrincipal Object principal, @PathVariable Long id) {
+        try {
+            Member member = (Member) principal;
+            postService.updateHeart(id, member);
+            return new ResponseEntity<>(null, HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(new ErrorResponse("존재하지 않는 게시글입니다."), HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/mooyeol/snsservice/controller/PostGetDto.java
+++ b/src/main/java/mooyeol/snsservice/controller/PostGetDto.java
@@ -25,7 +25,7 @@ public class PostGetDto {
 
         StringBuilder sb = new StringBuilder();
         for (PostTag postTag : post.getPostTags()) {
-            sb.append(postTag.getTag().getName() + ",");
+            sb.append(postTag.getPostTagName() + ",");
         }
         this.hashTags = sb.toString();
     }

--- a/src/main/java/mooyeol/snsservice/domain/PostTag.java
+++ b/src/main/java/mooyeol/snsservice/domain/PostTag.java
@@ -15,6 +15,9 @@ public class PostTag {
     @Column(name = "post_tag_id")
     private long id;
 
+    @Column(name = "post_tag_name")
+    private String postTagName;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
@@ -22,4 +25,5 @@ public class PostTag {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id")
     private Tag tag;
+
 }

--- a/src/main/java/mooyeol/snsservice/repository/heart/HeartRepository.java
+++ b/src/main/java/mooyeol/snsservice/repository/heart/HeartRepository.java
@@ -1,0 +1,15 @@
+package mooyeol.snsservice.repository.heart;
+
+import mooyeol.snsservice.domain.Heart;
+import mooyeol.snsservice.domain.Member;
+import mooyeol.snsservice.domain.Post;
+
+import java.util.Optional;
+
+public interface HeartRepository {
+    Optional<Heart> findHeart(Member member, Post post);
+
+    void saveHeart(Heart heart);
+
+    void deleteHeart(Heart heart);
+}

--- a/src/main/java/mooyeol/snsservice/repository/heart/HeartRepositoryImpl.java
+++ b/src/main/java/mooyeol/snsservice/repository/heart/HeartRepositoryImpl.java
@@ -1,0 +1,45 @@
+package mooyeol.snsservice.repository.heart;
+
+import mooyeol.snsservice.domain.Heart;
+import mooyeol.snsservice.domain.Member;
+import mooyeol.snsservice.domain.Post;
+
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import java.util.Optional;
+
+/**
+ * @Todo Cascade 설정(member - heart - post)
+ */
+public class HeartRepositoryImpl implements HeartRepository {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Override
+    public Optional<Heart> findHeart(Member member, Post post) {
+        try {
+            String jpql = "select h from Heart h where " +
+                    "h.member.id = :memberId " +
+                    "and h.post.id = :postId";
+            TypedQuery<Heart> query = em.createQuery(jpql, Heart.class)
+                    .setParameter("memberId", member.getId())
+                    .setParameter("postId", post.getId());
+            return Optional.of(query.getSingleResult());
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void saveHeart(Heart heart) {
+        em.persist(heart);
+    }
+
+    @Override
+    public void deleteHeart(Heart heart) {
+        em.remove(heart);
+    }
+}

--- a/src/main/java/mooyeol/snsservice/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/mooyeol/snsservice/repository/post/PostRepositoryImpl.java
@@ -33,13 +33,14 @@ public class PostRepositoryImpl implements PostRepository {
     @Override
     public Optional<Post> findPostWithHashTags(Long id) {
         try {
-            String queryStr = "SELECT p FROM Post p join fetch p.postTags where p.id = :id";
+            String queryStr = "SELECT distinct p FROM Post p join fetch p.postTags where p.id = :id";
             TypedQuery<Post> query = em.createQuery(queryStr, Post.class);
             query.setParameter("id", id);
             return Optional.of(query.getSingleResult());
         } catch (NoResultException e) {
             return Optional.empty();
         }
+
     }
 
     @Override
@@ -59,7 +60,6 @@ public class PostRepositoryImpl implements PostRepository {
         TypedQuery<Tag>  query = em.createQuery(queryStr, Tag.class);
         query.setParameter("hashTags", hashTags);
         return query.getResultList();
-
     }
 
     @Override
@@ -70,7 +70,7 @@ public class PostRepositoryImpl implements PostRepository {
     @Override
     public void savePostTag(PostTag postTag) {
         em.persist(postTag);
-        postTag.getPost().getPostTags().add(postTag);
+         postTag.getPost().getPostTags().add(postTag);
     }
 
 }

--- a/src/main/java/mooyeol/snsservice/security/config/AjaxSecurityConfig.java
+++ b/src/main/java/mooyeol/snsservice/security/config/AjaxSecurityConfig.java
@@ -43,6 +43,7 @@ public class AjaxSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.POST, "/post/**").authenticated()
                 .antMatchers(HttpMethod.PATCH, "/post/**").authenticated()
                 .antMatchers(HttpMethod.DELETE, "/post/**").authenticated()
+                .antMatchers(HttpMethod.POST, "/post/like/**").authenticated()
                 .anyRequest().permitAll()
                 .and()
                 .addFilterBefore(ajaxLoginProcessingFilter(), UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [*] 기능 추가 
- [] 기능 삭제 
- [] 버그 수정 
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [] 문서 작성
- [] 테스트 작성

### 반영 브랜치
feature/post-like-view -> dev

### 변경 사항
- 좋아요와 조회수 기능 구현
- 기존의 단일 게시글을 하나 조회하는 경우 N+1 문제가 발생하다는 걸 발견하고, 테이블 매핑을 최대한 건들지 않는 선에서 해결책을 찾다가
PostTag에 해시태그 이름을 저장하는 컬럼을 하나 더 추가해서 Tag를 N+1 조회하는 문제를 해결했다.
(모든 기능구현, 테스트를 마친 후에 해당 문제를 다른 방식으로 해결할 수 있을 지 더 고민!)